### PR TITLE
[Base] Removed `eslint-loader` that checks in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 node_modules/
 dist/
+coverage/
 npm-debug.log
+yarn-error.log
 test/e2e/reports
 selenium-debug.log

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -46,7 +46,9 @@ module.exports = {
     'selector-no-id': true,
     'selector-no-vendor-prefix': true,
     'selector-pseudo-class-case': 'lower',
-    'selector-pseudo-class-no-unknown': true,
+    'selector-pseudo-class-no-unknown': [true, {
+      ignorePseudoClasses: ['global']
+    }],
     'selector-pseudo-class-parentheses-space-inside': 'never',
     'selector-pseudo-element-case': 'lower',
     'selector-pseudo-element-colon-notation': 'single',

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+
+node_js:
+  - v7
+
+#after_success:
+#  - npm run coveralls
+
+notifications:
+  slack: cepave:6iJ2fA0ZKySiv109WCwTPgDt

--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -18,11 +18,10 @@ module.exports = {
     alias: {
       '~src': projectSrc,
       '~utils': path.join(projectSrc, 'utils'),
+      'sass': path.join(projectSrc, 'sass'),
     }
   },
-  resolveLoader: {
-    fallback: [path.join(__dirname, '../node_modules')]
-  },
+
   module: {
     loaders: [
       {

--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -25,14 +25,6 @@ module.exports = {
     fallback: [path.join(__dirname, '../node_modules')]
   },
   module: {
-    preLoaders: [
-      {
-        test: /\.js$/,
-        loader: 'eslint',
-        include: projectRoot,
-        exclude: /node_modules/
-      }
-    ],
     loaders: [
       {
         test: /\.js$/,

--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const config = require('../config')
-const projectRoot = path.resolve(__dirname, '../')
+const projectRoot = path.join(__dirname, '../')
+const projectSrc = path.join(projectRoot, 'src')
 const env = process.env.NODE_ENV
 
 module.exports = {
@@ -9,16 +10,14 @@ module.exports = {
   },
   output: {
     path: config.build.assetsRoot,
-    publicPath: process.env.NODE_ENV === 'production' ? config.build.assetsPublicPath : config.dev.assetsPublicPath,
+    publicPath: env === 'production' ? config.build.assetsPublicPath : config.dev.assetsPublicPath,
     filename: '[name].js'
   },
   resolve: {
     extensions: ['', '.js'],
-    fallback: [path.join(__dirname, '../node_modules')],
     alias: {
-      'src': path.resolve(__dirname, '../src'),
-      'assets': path.resolve(__dirname, '../src/assets'),
-      'components': path.resolve(__dirname, '../src/components')
+      '~src': projectSrc,
+      '~utils': path.join(projectSrc, 'utils'),
     }
   },
   resolveLoader: {
@@ -41,8 +40,5 @@ module.exports = {
         ]
       }
     ]
-  },
-  eslint: {
-    formatter: require('eslint-friendly-formatter')
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint --ext .js src test & stylelint src/**/*.scss --syntax scss"
   },
   "dependencies": {
+    "axios": "^0.15.3",
     "vue": "^2.1.4",
     "vue-owl-ui": "github:cepave-f2e/vue-owl-ui#v0.1.5"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "babel-node build/dev-server.js",
     "build": "babel-node build/build.js",
     "e2e": "babel-node test/e2e/runner.js",
-    "test": "npm run e2e",
+    "test": "npm run lint",
     "lint": "eslint --ext .js src test & stylelint src/**/*.scss --syntax scss"
   },
   "dependencies": {
@@ -35,7 +35,6 @@
     "eslint": "^3.7.1",
     "eslint-config-standard": "^6.1.0",
     "eslint-friendly-formatter": "^2.0.5",
-    "eslint-loader": "^1.5.0",
     "eslint-plugin-html": "^1.3.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-promise": "^2.0.1",

--- a/src/app.js
+++ b/src/app.js
@@ -1,11 +1,7 @@
-import Vue from 'vue'
-import router from './router'
-import store from './store'
 import s from './app.scss'
 
-module.exports = new Vue({
-  router,
-  store,
+module.exports = {
+  name: 'App',
   render(h) {
     return (
       <div id="app" class={s.app}>
@@ -13,4 +9,4 @@ module.exports = new Vue({
       </div>
     )
   }
-})
+}

--- a/src/app.scss
+++ b/src/app.scss
@@ -1,2 +1,2 @@
 // app.scss
-@import './sass/global'
+@import './sass/reset';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,10 @@
+import Vue from 'vue'
 import App from './app'
+import router from './router'
+import store from './store'
 
-App.$mount('#app')
+new Vue({
+  router,
+  store,
+  ...App
+}).$mount('#app')

--- a/src/sass/global.scss
+++ b/src/sass/global.scss
@@ -1,14 +1,3 @@
-@import "normalize.css/normalize.css";
-// css reset
-*, *:after, *:before {
-  box-sizing: border-box;
-}
+:global {
 
-*:after, *:before {
-  content: '';
-}
-
-ol, ul {
-  list-style: none;
-  margin: 0;
 }

--- a/src/sass/reset.scss
+++ b/src/sass/reset.scss
@@ -1,0 +1,14 @@
+@import "normalize.css/normalize.css";
+
+*, *:after, *:before {
+  box-sizing: border-box;
+}
+
+*:after, *:before {
+  content: '';
+}
+
+ol, ul {
+  margin: 0;
+  list-style: none;
+}

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -1,0 +1,33 @@
+import axios from 'axios'
+import { isBrowser } from './is-env'
+
+module.exports = (opts = {}) => {
+  const hasSpin = isBrowser && opts.spin
+  if (hasSpin) {
+    if (typeof opts.spin === 'string') {
+      opts.spin = Array.from(document.querySelectorAll(opts.spin))
+    } else if (!Array.isArray(opts.spin)) {
+      opts.spin = [opts.spin]
+    }
+
+    opts.spin.forEach((el) => {
+      el.style.visibility = 'visible'
+    })
+  }
+
+  return axios(opts)
+    .then((res)=> {
+      opts.spin.forEach((el) => {
+        el.style.visibility = 'hidden'
+      })
+
+      return res
+    })
+    .catch((er) => {
+      opts.spin.forEach((el) => {
+        el.style.visibility = 'hidden'
+      })
+
+      return er
+    })
+}

--- a/src/utils/is-env.js
+++ b/src/utils/is-env.js
@@ -1,0 +1,6 @@
+const isBrowser = typeof window !== 'undefined' && window.document && document.createElement
+const isNode = !isBrowser && typeof global !== 'undefined'
+
+module.exports = {
+  isBrowser, isNode
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -252,6 +252,12 @@ aws4@^1.2.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
+axios@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
+  dependencies:
+    follow-redirects "1.0.0"
+
 babel-cli:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.18.0.tgz#92117f341add9dead90f6fa7d0a97c0cc08ec186"
@@ -2120,6 +2126,12 @@ flat-cache@^1.2.1:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+follow-redirects@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"
+  dependencies:
+    debug "^2.2.0"
 
 for-in@^0.1.5:
   version "0.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1822,15 +1822,6 @@ eslint-import-resolver-node@^0.2.0:
     object-assign "^4.0.1"
     resolve "^1.1.6"
 
-eslint-loader@^1.5.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-1.6.1.tgz#96c47c812772eeb077e3a81681818e671a2cabf5"
-  dependencies:
-    find-cache-dir "^0.1.1"
-    loader-utils "^0.2.7"
-    object-assign "^4.0.1"
-    object-hash "^1.1.4"
-
 eslint-module-utils@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
@@ -3641,10 +3632,6 @@ oauth-sign@~0.8.1:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
-
-object-hash@^1.1.4:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.1.5.tgz#bdd844e030d0861b692ca175c6cab6868ec233d7"
 
 object.omit@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
- 拔除 eslint 到 CI 上
- 新增基於 axios 的 request,  所有 `opitions` 都跟 `axios` 文件一樣，只有差別在於新增 `spin` 來指定 loading 的顯示或隱藏， 設定好之後，就可以輕鬆地把每次都需要用到的 loading 解耦，程式會自動在請求時顯示 loading 在請求完畢後隱藏。

```jsx
import fetch from '~utils/fetch'
import { Loading } from 'vue-owl-ui'

mounted() {
  fetch({
    ...,
    spin: this.$refs.spin1.$el, // or selector '#spin1' or Array [...]
  })
  .then(...)
  .catch(...)
},
render(h) {
  return (
    <div>
       <Loading ref="spin1" id="spin1" />
    </div>
  )
}
```