### PR TITLE
Add <ECharts /> component

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -18,6 +18,7 @@ module.exports = {
     alias: {
       '~src': projectSrc,
       '~utils': path.join(projectSrc, 'utils'),
+      '~coms': path.join(projectSrc, 'components'),
       '~sass': path.join(projectSrc, 'sass'), // for js
       'sass': path.join(projectSrc, 'sass'), // for scss
     }

--- a/src/components/echarts.js
+++ b/src/components/echarts.js
@@ -1,0 +1,56 @@
+import fixUnit from '~utils/fix-unit'
+
+const ECharts = {
+  name: 'ECharts',
+  props: {
+    options: {
+      type: Object,
+    },
+    size: {
+      type: [Number, String],
+      default: '600x375',
+    }
+  },
+
+  mounted() {
+    const { $el, options, _events } = this
+
+    this.Chart = window.echarts.init($el)
+    this.Chart.setOption(options)
+
+    Object.keys(_events).forEach((ev) => {
+      this.Chart.on(ev, (params) => {
+        this.$emit(ev, params)
+      })
+    })
+  },
+
+  computed: {
+    style() {
+      const { size } = this
+      let width, height
+
+      if (typeof size === 'number') {
+        width = height = size
+      } else {
+        [width, height] = size.split('x')
+
+        width = fixUnit(width)
+        height = fixUnit(height)
+      }
+
+      return {
+        width, height
+      }
+    }
+  },
+
+  render(h) {
+    const { style } = this
+    return (
+      <div style={style} />
+    )
+  }
+}
+
+module.exports = ECharts

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
     <script src="//cdn.bootcss.com/lodash.js/4.17.2/lodash.min.js"></script>
     <script src="//cdn.bootcss.com/axios/0.15.3/axios.min.js"></script>
     <script src="//cdn.bootcss.com/js-cookie/latest/js.cookie.min.js"></script>
+    <script src="//cdn.bootcss.com/echarts/3.3.2/echarts.min.js"></script>
     <!-- built files will be auto injected -->
   </body>
 </html>

--- a/src/utils/__test__/fix-unit.spec.js
+++ b/src/utils/__test__/fix-unit.spec.js
@@ -1,0 +1,31 @@
+import fixUnit from '../fix-unit'
+
+it('if unit not a `string` or `number`', () => {
+  expect(() => {
+    fixUnit({})
+  }).toThrow()
+
+  expect(() => {
+    fixUnit([])
+  }).toThrow()
+})
+
+it('if not a legal number string', () => {
+  expect(() => {
+    fixUnit('')
+  }).toThrow()
+
+  expect(() => {
+    fixUnit('x123')
+  }).toThrow()
+})
+
+it('If have no unit, it should be return as `px`', () => {
+  expect(fixUnit('87')).toBe('87px')
+  expect(fixUnit(87)).toBe('87px')
+})
+
+it('If have set unit, it should be return as unit', () => {
+  expect(fixUnit('87%')).toBe('87%')
+  expect(fixUnit('87em')).toBe('87em')
+})

--- a/src/utils/fix-unit.js
+++ b/src/utils/fix-unit.js
@@ -1,0 +1,18 @@
+const fixUnit = (unit) => {
+  if (!/^(string|number)$/.test(typeof unit)) {
+    throw new Error(`${unit} is not a string or number.`)
+  }
+
+  if (typeof unit === 'string' && isNaN(parseFloat(unit))) {
+    throw new Error(`${unit} is not a legal number-string.`)
+  }
+
+  unit = String(unit)
+
+  if (/\d$/.test(unit)) {
+    return `${unit}px`
+  }
+  return unit
+}
+
+module.exports = fixUnit


### PR DESCRIPTION
- Added `fix-unit` utils
- Added webpack `resolve.alias`: `~coms`
- ECharts documentation
 
# ECharts

## Props

```js
props: {
  options: {
    type: Object,
  },
  size: {
    type: [Number, String],
    default: '600x375',
  }
},
```



## Usage

```jsx
import ECharts from '~com/echarts'
render(h) {
  return (
    <div>
      <ECharts size="700x400" options={...echarts options here} />
    </div>
  )
}
```



## Options
All available options:
http://echarts.baidu.com/option.html



## Instance

Access `Chart` inctance from component `$refs`.

```jsx
import ECharts from '~com/echarts'
mounted(){
  this.$refs.chart1.Chart
},
render(h) {
  return (
    <div>
      <ECharts size="700x400" options={...echarts options here} ref="chart1" />
    </div>
  )
}
```
## Events

Each event will be `$emit` form compoent inside, there are all lists of event:
http://echarts.baidu.com/api.html#events

```jsx
import ECharts from '~coms/echarts'

render(h) {
  return (
    <div>
      <ECharts on-eventname={()=>...} size="700x400" options={...echarts options here} />
    </div>
  )
}
```

