### PR TITLE
[Utils] Added `bytes` until for convert bytes

### DIFF
--- a/src/utils/__test__/bytes.spec.js
+++ b/src/utils/__test__/bytes.spec.js
@@ -1,0 +1,39 @@
+import bytes from '../bytes'
+
+it('Convert from number', () => {
+  expect(bytes(87)).toBe('87')
+  expect(bytes(8787)).toBe('8.79K')
+  expect(bytes(878787)).toBe('878.79K')
+  expect(bytes(87878787)).toBe('87.88M')
+  expect(bytes(8787878787)).toBe('8.79G')
+  expect(bytes(8787878787878)).toBe('8.79T')
+})
+
+it('Convert from string', () => {
+  expect(bytes('87')).toBe(87)
+  expect(bytes('8.79K')).toBe(8790)
+  expect(bytes('87K')).toBe(87000)
+  expect(bytes('87M')).toBe(87000 * 1000)
+  expect(bytes('87G')).toBe(87000 * 1000 * 1000)
+  expect(bytes('87T')).toBe(87000 * 1000 * 1000 * 1000)
+})
+
+it('Test with `space`', () => {
+  expect(bytes(8787, { space: true })).toBe('8.79 K')
+})
+
+it('Test with `decimals`', () => {
+  expect(bytes(8787, { decimals: 1 })).toBe('8.8K')
+})
+
+it('Throw error if pass not a string or number', () => {
+  expect(() => {
+    bytes({})
+  }).toThrow()
+})
+
+it('Throw error if pass a invalid string', () => {
+  expect(() => {
+    bytes('87A')
+  }).toThrow()
+})

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -1,0 +1,53 @@
+const u = 1000 // or 1024
+
+const K = u
+const M = K * u
+const G = M * u
+const T = G * u
+
+const uMap = {
+  T, G, M, K
+}
+
+module.exports = (val, opts = {}) => {
+  opts = {
+    decimals: 2,
+    space: false,
+    ...opts
+  }
+
+  if (typeof val === 'number') {
+    let unit
+    if (val >= T) {
+      unit = 'T'
+    } else if (val >= G) {
+      unit = 'G'
+    } else if (val >= M) {
+      unit = 'M'
+    } else if (val >= K) {
+      unit = 'K'
+    }
+
+    if (unit) {
+      const space = opts.space ? ' ' : ''
+      val = (val / uMap[unit]).toFixed(opts.decimals)
+      return `${val}${space}${unit}`
+    }
+
+    return `${val}`
+  } else if (typeof val === 'string') {
+    const unit = val.substr(-1)
+
+    if (uMap[unit]) {
+      return parseFloat(val) * uMap[unit]
+    } else {
+      if (/^\d$/.test(unit)) {
+        return +val
+      }
+      throw new Error('The units are not: K, M, G and T')
+    }
+
+  } else {
+    throw new Error(`${val} is not a number or string`)
+  }
+}


### PR DESCRIPTION
## Usage
### bytes(number, options)
```js
import bytes from '~utils/bytes'

bytes(8787) // output 8.79K

bytes('8.7K') // output 8700
```

## Options
### space [Boolean] (false)
數字與單位保持空白

### decimals [Number] (2)
小數點幾位後四捨五入進位