### PR TITLE
[DatePicker] Added `DatePicker` component

### DIFF
--- a/src/components/date-picker/date-picker.scss
+++ b/src/components/date-picker/date-picker.scss
@@ -1,0 +1,105 @@
+@import "~sass/colors";
+
+.picker {
+  display: table;
+  border: 1px solid $colorGrayLight;
+  position: relative;
+  cursor: pointer;
+  &:hover {
+    border-color: $colorPrimaryLight;
+  }
+  input {
+    border: none;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    cursor: pointer;
+    padding-left: 8px;
+    &:focus {
+      outline: none;
+    }
+  }
+}
+.icon {
+  fill: $colorPrimary;
+  position: absolute;
+  top: 50%;
+  right: 5px;
+  z-index: 2;
+  transform: translateY(-50%);
+}
+
+.container {
+  font-weight: 300;
+  display: none;
+  border: 1px solid $colorPrimary;
+  background: $colorGrayLightest;
+  padding: 4px;
+  padding-top: 12px;
+  text-align: center;
+  font-size: 12px;
+  min-width: 216px;
+  min-height: 216px;
+
+  th {
+    font-weight: 300;
+  }
+}
+
+.day {
+  padding: 4px;
+  cursor: pointer;
+  &:hover {
+    background: $colorPrimary;
+    color: #fff;
+  }
+}
+
+.daySelected {
+  border-radius: 50%;
+}
+.daySelected, .timeSelected {
+  background: $colorPrimary;
+  color: #fff;
+}
+
+.timeSelected, .timeOption {
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.timeOption {
+  &:hover {
+    background: $colorPrimary;
+    color: #fff;
+  }
+}
+
+.back, .next {
+  padding: 0 4px;
+  height: auto;
+  background: transparent;
+  margin-top: -4px;
+}
+.back {
+  float: left;
+  &:after {
+    content: '❮';
+  }
+}
+.next {
+  float: right;
+  &:after {
+    content: '❯';
+  }
+}
+
+.month {
+  padding-top: 4px;
+  margin: 0 auto;
+}
+
+.days {
+  margin: 0 auto;
+}

--- a/src/components/date-picker/index.js
+++ b/src/components/date-picker/index.js
@@ -1,0 +1,94 @@
+import { Icon } from 'vue-owl-ui'
+import s from './date-picker.scss'
+import fixUnit from '~utils/fix-unit'
+const { rome, moment } = window
+
+const DatePicker = {
+  name: 'DatePicker',
+  props: {
+    width: {
+      type: [String, Number],
+      default: 168,
+    },
+    height: {
+      type: [String, Number],
+      default: 28,
+    },
+
+    readOnly: {
+      type: Boolean,
+      default: false,
+    },
+    opts: {
+      type: Object,
+    },
+  },
+  mounted() {
+    const { opts } = this
+    this.Picker = rome(this.$refs.date, {
+      inputFormat: 'YYYY/MM/DD HH:mm',
+      styles: {
+        back: s.back,
+        container: s.container,
+        date: 'rd-date',
+        dayBody: 'rd-days-body',
+        dayBodyElem: s.day,
+        dayConcealed: 'rd-day-concealed',
+        dayDisabled: 'rd-day-disabled',
+        dayHead: 'rd-days-head',
+        dayHeadElem: 'rd-day-head',
+        dayRow: 'rd-days-row',
+        dayTable: 'rd-days',
+        month: 'rd-month',
+        next: s.next,
+        positioned: 'rd-container-attachment',
+        selectedDay: s.daySelected,
+        selectedTime: s.timeSelected,
+        time: 'rd-time',
+        timeList: 'rd-time-list',
+        timeOption: s.timeOption,
+      },
+      ...opts,
+    })
+  },
+
+  methods: {
+    showPicker() {
+      return this.Picker.show()
+    },
+
+    handleChange(ev) {
+      const input = ev.currentTarget
+      if (!input.value) {
+        return
+      }
+
+      this.$emit('change', {
+        format: input.value,
+        unix: moment(new Date(input.value)).unix(),
+      })
+    }
+  },
+  computed: {
+    style() {
+      const { width, height } = this
+      return {
+        width: fixUnit(width),
+        height: fixUnit(height),
+      }
+    }
+  },
+  render(h) {
+    const { style, handleChange, readOnly, showPicker } = this
+    return (
+      <div class={[s.picker]} style={style}>
+        <input readOnly={readOnly} ref="date" onBlur={handleChange} />
+        <Icon typ="date" size={18} class={[s.icon]} nativeOnMousedown={showPicker} nativeOnClick={(e) => {
+          e.stopPropagation()
+        }} />
+      </div>
+    )
+  }
+}
+
+module.exports = DatePicker

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>owl-light-vue</title>
     <link href="//unpkg.com/normalize.css" rel="stylesheet" />
+    <link href="//unpkg.com/rome/dist/rome.min.css" rel="stylesheet" />
   </head>
   <body>
     <div id="app"></div>
@@ -17,5 +18,6 @@
     <script src="//unpkg.com/echarts/dist/echarts.min.js"></script>
     <script src="//unpkg.com/qs/dist/qs.js"></script>
     <script src="//unpkg.com/moment"></script>
+    <script src="//unpkg.com/rome/dist/rome.standalone.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
![date-picker](https://cloud.githubusercontent.com/assets/890063/21540072/b778b9be-ce00-11e6-8e30-803c6f33b922.gif)

樣式調了很久呢 QQ

# DatePicker

## Props
```js
props: {
    width: {
      type: [String, Number],
      default: 168,
    },
    height: {
      type: [String, Number],
      default: 28,
    },

    readOnly: {
      type: Boolean,
      default: false,
    },
    opts: {
      type: Object,
    },
  },
```

## Usage

```jsx
import DatePicker from '~coms/date-picker`

```
## Options
All available options are same as `rome`
https://github.com/bevacqua/rome#default-options

## Events

### onChange({ format, unix })
get time's format and unix stamp