### PR TITLE
Add `margin: 0` to body selector

### DIFF
--- a/src/sass/reset.scss
+++ b/src/sass/reset.scss
@@ -16,6 +16,7 @@ ol, ul, dl, dd {
 
 body {
   background: #e6ebef;
+  margin: 0;
 }
 
 body, input, textarea, button {


### PR DESCRIPTION
Add `margin: 0` to body selector in  reset.scss to fix normalize.css v6 issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cepave-f2e/owl-light/78)
<!-- Reviewable:end -->
